### PR TITLE
Add ability to remove event listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ var ON_DEATH = require('death')({SIGHUP: true})
 Name it whatever you want. I like `ON_DEATH` because it stands out like a sore thumb in my code.
 
 
+#### Want to remove event handlers?
+
+If you want to remove event handlers `ON_DEATH` returns a function for cleaning
+up after itself:
+
+```js
+var ON_DEATH = require('death')
+var OFF_DEATH = ON_DEATH(function(signal, err) {
+  //clean up code here
+})
+
+// later on...
+OFF_DEATH();
+```
 
 License
 -------

--- a/lib/death.js
+++ b/lib/death.js
@@ -9,24 +9,37 @@ var defaultConfig = {
 var DEBUG = false
 
 function ON_DEATH (callback) {
+  var handlers = [];
   Object.keys(defaultConfig).forEach(function(key) {
     var val = defaultConfig[key]
+    var handler = null;
     if (val) {
-      if (DEBUG)
-        process.on(key, function() {
+      if (DEBUG) {
+        handler = function() {
           var args = Array.prototype.slice.call(arguments, 0)
           args.unshift(key)
           console.log('Trapped ' + key)
           callback.apply(null, args)
-        })
-      else
-        process.on(key, function() {
+        };
+        process.on(key, handler)
+      } else {
+        handler = function() {
           var args = Array.prototype.slice.call(arguments, 0)
           args.unshift(key)
           callback.apply(null, args)
-        })
+        }
+        process.on(key, handler)
+      }
+      handlers.push([key, handler])
     }
   })
+  return function OFF_DEATH() {
+    handlers.forEach(function (args) {
+      var key = args[0];
+      var handler = args[1];
+      process.removeListener(key, handler);
+    })
+  }
 }
 
 module.exports = function (arg) {
@@ -46,7 +59,7 @@ module.exports = function (arg) {
 
     return ON_DEATH
    } else if (typeof arg === 'function') {
-    ON_DEATH(arg)
+    return ON_DEATH(arg)
   }
 }
 


### PR DESCRIPTION
It is a good idea to remove event listeners when they are no longer
required, as they can slow a process down or have odd consequences when
fired in the wrong context.

I have added the ability to remove the event listeners that ON_DEATH
sets up by collecting pairs of keys and handlers together and returning
a function that can be invoked which runs removeListener using these
pairs as arguments.

This can be used later like so:

```
var ON_DEATH = require('death')
var OFF_DEATH = ON_DEATH(function(signal, err) {
  //clean up code here
})

// later on...
OFF_DEATH();
```
